### PR TITLE
feat: allow table data to expire even if no cookie maxAge is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ export async function loader({ request }) {
   - `httpOnly`: HttpOnly attribute
   - `secure`: Secure attribute
   - `domain`: Cookie domain
+- `sessionMaxAge` (optional): The max age of table entries when no cookie maxAge is set
+
+  > [!NOTE]
+  > By default, react-router only sets session data to expire when the
+  > cookie has a maxAge (or expires date) set. When using session cookies,
+  > such an expiry time does not exist, and in theory, such cookies can be
+  > kept alive by the browser indefinitely.
+  >
+  > However, it can still be desired to let the session data in the table
+  > expire at some point in the near or distant future, which can be set
+  > with the `sessionMaxAge` property.
 
 ## DynamoDB Table Requirements
 


### PR DESCRIPTION
Add `sessionMaxAge` property that let's you configure when the table data is supposed to expire when no max age is configured.

By default, react-router only sets session data to expire when the cookie has a maxAge (or expires date) set. When using session cookies, such an expiry time does not exist, and in theory, such cookies can be kept alive by the browser indefinitely.
However, it can still be desired to let the session data in the table expire at some point in the near or distant future, which can be set with this new property.