### PR TITLE
chore: group release notes into titled changelog categories

### DIFF
--- a/.github/release-drafter-prerelease.yml
+++ b/.github/release-drafter-prerelease.yml
@@ -19,7 +19,7 @@ categories:
     when:
       labels:
         - patch
-  - title: "📝 Other Changes"
+  - title: "📝 Documentation & Other Changes"
   - type: version-resolver
     semver-increment: patch
   - type: pre-exclude

--- a/.github/release-drafter-prerelease.yml
+++ b/.github/release-drafter-prerelease.yml
@@ -19,6 +19,7 @@ categories:
     when:
       labels:
         - patch
+  - title: "📝 Other Changes"
   - type: version-resolver
     semver-increment: patch
   - type: pre-exclude

--- a/.github/release-drafter-prerelease.yml
+++ b/.github/release-drafter-prerelease.yml
@@ -4,17 +4,17 @@ tag-template: 'v$RESOLVED_VERSION'
 prerelease: true
 prerelease-identifier: rc
 categories:
-  - type: version-resolver
+  - title: "💥 Breaking Changes"
     semver-increment: major
     when:
       labels:
         - major
-  - type: version-resolver
+  - title: "🚀 Features"
     semver-increment: minor
     when:
       labels:
         - minor
-  - type: version-resolver
+  - title: "🐛 Bug Fixes & Improvements"
     semver-increment: patch
     when:
       labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,17 +2,17 @@
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
-  - type: version-resolver
+  - title: "💥 Breaking Changes"
     semver-increment: major
     when:
       labels:
         - major
-  - type: version-resolver
+  - title: "🚀 Features"
     semver-increment: minor
     when:
       labels:
         - minor
-  - type: version-resolver
+  - title: "🐛 Bug Fixes & Improvements"
     semver-increment: patch
     when:
       labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -17,7 +17,7 @@ categories:
     when:
       labels:
         - patch
-  - title: "📝 Other Changes"
+  - title: "📝 Documentation & Other Changes"
   - type: version-resolver
     semver-increment: patch
   - type: pre-exclude

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -17,6 +17,7 @@ categories:
     when:
       labels:
         - patch
+  - title: "📝 Other Changes"
   - type: version-resolver
     semver-increment: patch
   - type: pre-exclude


### PR DESCRIPTION
## Summary

Gives this repo's drafted release notes the same grouped headings as react-router-aws (#15/#17), instead of one flat `$CHANGES` list. The three labeled `version-resolver` categories become titled changelog categories (keeping their `semver-increment` + `when`), plus a title-only catch-all so uncategorized PRs land at the bottom. Applied to both `release-drafter.yml` and `release-drafter-prerelease.yml`.

```diff
 categories:
-  - type: version-resolver
-    semver-increment: major
-    when: { labels: [major] }
-  - type: version-resolver
-    semver-increment: minor
-    when: { labels: [minor] }
-  - type: version-resolver
-    semver-increment: patch
-    when: { labels: [patch] }
+  - title: "💥 Breaking Changes"
+    semver-increment: major
+    when: { labels: [major] }
+  - title: "🚀 Features"
+    semver-increment: minor
+    when: { labels: [minor] }
+  - title: "🐛 Bug Fixes & Improvements"
+    semver-increment: patch
+    when: { labels: [patch] }
+  - title: "📝 Documentation & Other Changes"   # catch-all (no when:) -> renders last
   - { type: version-resolver, semver-increment: patch }   # default
   - { type: pre-exclude, when: { labels: [ignore-for-release] } }
```

Version resolution is unchanged (titled categories still carry `semver-increment`); only the notes layout changes. The catch-all has no `semver-increment` (display-only). Mirrors the merged react-router-aws config.

Link to Devin session: https://app.devin.ai/sessions/3bdfc4e1eef54b07af2479fdcd73e0f3
Requested by: @oxc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/geostrategists/react-router-sessions-dynamodb/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->