### PR TITLE
feat: support react-router 8 in react-router-sessions-dynamodb

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "lefthook": "^2.1.9",
     "oxfmt": "^0.54.0",
     "oxlint": "^1.69.0",
-    "react-router": "^7.3.0",
+    "react": "^19.2.7",
+    "react-router": "^8.0.1",
     "rimraf": "^6.1.2",
     "tsdown": "^0.22.2",
     "typescript": "^5.9.3"
@@ -59,7 +60,7 @@
   "peerDependencies": {
     "@aws-sdk/client-dynamodb": "^3.0.0",
     "@aws-sdk/lib-dynamodb": "^3.0.0",
-    "react-router": "^7.0.0"
+    "react-router": "^7.0.0 || ^8.0.0"
   },
   "engines": {
     "node": ">=24"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,12 @@ importers:
       oxlint:
         specifier: ^1.69.0
         version: 1.69.0
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
       react-router:
-        specifier: ^7.3.0
-        version: 7.17.0(react@19.2.7)
+        specifier: ^8.0.1
+        version: 8.0.1(react@19.2.7)
       rimraf:
         specifier: ^6.1.2
         version: 6.1.3
@@ -627,9 +630,8 @@ packages:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -809,12 +811,12 @@ packages:
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
 
-  react-router@7.17.0:
-    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.0.1:
+    resolution: {integrity: sha512-5EL/fANovVUhRK50NLS8RYfX0BxrimoKsHWUPPy8v5UEl8i6vzF7e4POo3u+AhPItDwccUAJjMfIOmydxBJmQw==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -859,9 +861,6 @@ packages:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   strnum@2.4.0:
     resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
@@ -1473,7 +1472,7 @@ snapshots:
 
   cac@7.0.0: {}
 
-  cookie@1.1.1: {}
+  cookie-es@3.1.1: {}
 
   defu@6.1.7: {}
 
@@ -1637,11 +1636,10 @@ snapshots:
 
   quansync@1.0.0: {}
 
-  react-router@7.17.0(react@19.2.7):
+  react-router@8.0.1(react@19.2.7):
     dependencies:
-      cookie: 1.1.1
+      cookie-es: 3.1.1
       react: 19.2.7
-      set-cookie-parser: 2.7.2
 
   react@19.2.7: {}
 
@@ -1690,8 +1688,6 @@ snapshots:
       '@rolldown/binding-win32-x64-msvc': 1.1.0
 
   semver@7.8.4: {}
-
-  set-cookie-parser@2.7.2: {}
 
   strnum@2.4.0:
     dependencies:


### PR DESCRIPTION
## Summary

Makes `@geostrategists/react-router-sessions-dynamodb` compatible with **react-router 8** so it stops being a blocker for the portal frontends' eventual RR8 upgrade, while staying valid for the RR7 they run today.

The adapter only touches react-router's session API — `createSessionStorage` (runtime) and the `FlashSessionData` / `SessionData` / `SessionIdStorageStrategy` / `SessionStorage` types — all of which are unchanged and still exported by RR8. So it builds, typechecks and lints cleanly against RR8 with **no source changes**; this PR is purely dependency-metadata.

```diff
 "peerDependencies": {
-  "react-router": "^7.0.0"
+  "react-router": "^7.0.0 || ^8.0.0"
 },
 "devDependencies": {
+  "react": "^19.2.7",
-  "react-router": "^7.3.0",
+  "react-router": "^8.0.1",
 }
```

- The **dual peer range** keeps current RR7 consumers valid while unblocking RR8. `react-router@8.0.1` is >24h old.
- `react@^19.2.7` is added as a **devDependency** to satisfy RR8's required `react>=19.2.7` peer in the dev tree, so `pnpm install` is peer-clean and the RR8 build/typecheck actually run against the supported peer range. The package itself declares no `react` dep (it's server-only) — consumers bring their own. The existing `engines.node: ">=24"` already covers RR8's `node>=22.22.0` requirement.

Validated locally against RR8: `pnpm build`, `pnpm typecheck`, `pnpm lint` (oxlint), `pnpm format:check` all green, `pnpm install` reports no peer warnings.

Link to Devin session: https://app.devin.ai/sessions/3264b70b028e4a7da8f8cd6776bc71e1
Requested by: @oxc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/geostrategists/react-router-sessions-dynamodb/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->